### PR TITLE
Add static to Class Decloration

### DIFF
--- a/tests/UnitTests.cs
+++ b/tests/UnitTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace TurtleChallenge
 {
-    public class UnitTests{
+    public static class UnitTests{
         [Fact]
         public static void PositionTest()
         {


### PR DESCRIPTION
### Issue #5

Utility classes, which are collections of static members, are not meant to be instantiated. Even abstract utility classes, which can be extended, should not have public constructors.

C# adds an implicit public constructor to every class which does not explicitly define at least one constructor. Hence, at least one protected constructor should be defined if you wish to subclass this utility class. Or the static keyword should be added to the class declaration to prevent subclassing.